### PR TITLE
Fixes for Grid on Windows Phone and IE11

### DIFF
--- a/client/assets/scss/app.scss
+++ b/client/assets/scss/app.scss
@@ -649,3 +649,75 @@ a.legenda-button {
         box-shadow: 0 2.5em 0 0 #ffffff;
     }
 }
+
+
+// --[ Fixes for Windows Mobile / Internet Explorer 11 and Edge ]---------------
+// Add a max-width to flex items.
+
+.grid-container {
+    width: 100%;
+}
+
+// Proper fix for ZURB is to add the following rule in `components/_grid.scss`
+//
+//     max-width: percentage(1 / $up);
+//
+// Like so:
+//
+//     @mixin grid-layout($up) {
+//       flex-flow: row wrap;
+//       overflow: visible;
+//       list-style-type: none;
+//
+//       > li, > div, > section {
+//         padding: 0 1rem 1rem;
+//         flex: 0 0 percentage(1 / $up);
+//         max-width: percentage(1 / $up);
+//       }
+//     }
+//
+
+@include breakpoint(small) {
+    .small-up-1 > .grid-content {
+        max-width: 100%;
+    }
+    .small-up-2 > .grid-content {
+        max-width: 50%;
+    }
+    .small-up-3 > .grid-content {
+        max-width: 33.33333%;
+    }
+    .small-up-4 > .grid-content {
+        max-width: 25%;
+    }
+}
+
+@include breakpoint(medium) {
+    .medium-up-1 > .grid-content {
+        max-width: 100%;
+    }
+    .medium-up-2 > .grid-content {
+        max-width: 50%;
+    }
+    .medium-up-3  > .grid-content {
+        max-width: 33.33333%;
+    }
+    .medium-up-4 > .grid-content {
+        max-width: 25%;
+    }
+}
+
+@include breakpoint(large) {
+    .large-up-1 > .grid-content {
+        max-width: 100%;
+    }
+    .large-up-2 > .grid-content {
+        max-width: 50%;
+    }
+    .large-up-3 > .grid-content {
+        max-width: 33.33333%;
+    }
+    .large-up-4 > .grid-content {
+        max-width: 25%;
+    }
+}

--- a/client/templates/programma.html
+++ b/client/templates/programma.html
@@ -18,24 +18,28 @@ title: Programma
 
         <!-- grid for navigation -->
         <div class="grid-block small-up-2 medium-up-3 large-up-3">
-            <div class="grid-content content-act {{ speeltijd.attributes.starttijd | date : 'EEE' }}"
+            <div class="grid-content content-act {{ ::speeltijd.attributes.starttijd | date : 'EEE' }}"
             ng-repeat="speeltijd in speeltijden"
             ng-if="(filter == (speeltijd.attributes.starttijd | date : 'EEE') || filter == 'alle')
                 && (speeltijd.attributes.programmaonderdelen != 0)">
 
                 <a ui-sref="onderdeel({ id: speeltijd.attributes.programmaonderdelen })">
-                    <article class="thema thema-{{ speeltijd.id }}" style="background-image: url({{ speeltijd.attributes.image.thumbnail }});">
+                    <article class="thema thema-{{ ::speeltijd.id }}"
+                        ng-style="backgroundImage"
+                        ng-init="backgroundImage = { 'background-image' : 'url(' + speeltijd.attributes.image.thumbnail + ')' }">
 
-                    <span ng-if="favs[speeltijd.attributes.programmaonderdelen]" class="heart-fav" style="transform: rotate({{ randomRotate(speeltijd.id) }}deg);">
+                    <span ng-if="favs[speeltijd.attributes.programmaonderdelen]" class="heart-fav"
+                        ng-style="randomRotation"
+                        ng-init="randomRotation = { 'transform': 'rotate(' + randomRotate(speeltijd.id) + 'deg)' }">
                        <i class="fa fa-heart"></i>
                     </span>
 
                     <span> &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </span>
 
                     <div class="caption">
-                        <!-- <img src="{{ bericht.attributes.image.thumbnail }}" width="100" height="100"> -->
-                        <h2><i class="fa fa-clock-o"></i> {{ speeltijd.attributes.starttijd | date : 'EEE H:mm' }} - {{ speeltijd.attributes.speellokatie }}</h2>
-                        <h1 class="">{{ speeltijd.attributes.title }}</h1>
+                        <!-- <img src="{{ ::bericht.attributes.image.thumbnail }}" width="100" height="100"> -->
+                        <h2><i class="fa fa-clock-o"></i> {{ ::speeltijd.attributes.starttijd | date : 'EEE H:mm' }} - {{ ::speeltijd.attributes.speellokatie }}</h2>
+                        <h1 class="">{{ ::speeltijd.attributes.title }}</h1>
                     </div>
                     </article>
                 </a>


### PR DESCRIPTION
Apparently, you can use `{{ ::variableName }}` for a one-time binding (better performance).