### PR TITLE
Remember scroll position on programme overview page.

### DIFF
--- a/client/assets/js/itgwo.js
+++ b/client/assets/js/itgwo.js
@@ -215,39 +215,6 @@
 
   // --[ Directives ]-----------------------------------------------------------
 
-  itgwo.directive("getThema",
-    ['$http', '$filter', 'config', '$state',
-    function($http, $filter, config, $state) {
-
-    return {
-      template: '<span class="label">{{ thema }}</span>', // TODO: make these things nice with includes?
-      scope: {
-        onderwerpSlug: "=getThema"
-      },
-      link: function(scope, element, attrs) {
-
-        var key = $filter('key');
-        var value = $filter('value');
-        var slug = $filter('slug');
-
-        $http
-        .get(config.api.url + 'onderwerpen/' + scope.onderwerpSlug, { cache: true })
-        .then(function(result) {
-
-          var themaName = value(result.data.data.attributes.taxonomy.themas);
-          var themaId = slug(key(result.data.data.attributes.taxonomy.themas));
-          scope.thema = themaName;
-          element[0].href = $state.href('thema', { id : themaId });
-
-        }, function(err) {
-          scope.thema = "Unknown";
-          scope.url = "#";
-        });
-      }
-    }
-  }]);
-
-
   // Generic back button.
   itgwo.directive('backButton', ['$window', function ($window) {
     return {
@@ -259,6 +226,5 @@
       }
     };
   }]);
-
 
 })();

--- a/client/assets/js/itgwo/controller/programmas.js
+++ b/client/assets/js/itgwo/controller/programmas.js
@@ -4,8 +4,8 @@
   var itgwo = angular.module('itgwo');
 
   itgwo.controller('itgwo.controller.programma', [
-    '$scope', '$sce', '$controller', '$state','$http', '$rootScope', 'config', 'itgwo.service.notification', 'itgwo.service.localstorage',
-    function ($scope, $sce, $controller, $state, $http, $rootScope, config, itgwoServiceNotification, itgwoServiceLocalstorage) {
+    '$scope', '$sce', '$controller', '$state','$http', '$rootScope', '$window', '$timeout', 'config', 'itgwo.service.notification', 'itgwo.service.localstorage',
+    function ($scope, $sce, $controller, $state, $http, $rootScope, $window, $timeout, config, itgwoServiceNotification, itgwoServiceLocalstorage) {
 
       // Storing in $rootScope is generally not a good idea... It is a better
       // idea to make a service/factory instead. But $watch is nice as well (for
@@ -72,6 +72,25 @@
           });
         });
 
+        // --[ track scroll position between pages ]------------------------------
+        // This is specifically for the programme overview ONLY.
+
+        // Add this function only once... could probably be neater.
+        if ($rootScope.trackScrollPosition != true) {
+          $rootScope.$on('$locationChangeSuccess', function() {
+            // console.log($rootScope.scrollPosCache);
+            var position = $rootScope.scrollPosCache[$window.location.href] || 0;
+            $timeout(function() {
+              $('[ui-view] :first').scrollTop(position);
+            }, 0);
+          });
+          $rootScope.trackScrollPosition = true;
+        }
+
+        $scope.$on("$destroy", function() {
+          $rootScope.scrollPosCache = $rootScope.scrollPosCache || [];
+          $rootScope.scrollPosCache[$window.location.href] = $('[ui-view] :first').scrollTop();
+        });
 
       }
 


### PR DESCRIPTION
Remembers where you left off when going from `programma` to `onderdeel` and then back, if you know what I mean. Made this specifically only for programme overview, because remembering the exact location on every page didn't always make sense to me. (Otherwise move this back to `base.js` and add some IF-statements).